### PR TITLE
feat!: Introduce a FileSystem interface

### DIFF
--- a/src/FS.php
+++ b/src/FS.php
@@ -59,14 +59,14 @@ use function func_get_args;
  */
 class FS
 {
-    private static NativeFileSystem $filesystem;
+    private static FileSystem $filesystem;
 
-    public static function setInstance(NativeFileSystem $filesystem): void
+    public static function setInstance(FileSystem $filesystem): void
     {
         self::$filesystem = $filesystem;
     }
 
-    public static function getInstance(): NativeFileSystem
+    public static function getInstance(): FileSystem
     {
         /** @psalm-suppress RedundantPropertyInitializationCheck */
         if (!isset(self::$filesystem)) {

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -48,7 +48,7 @@ namespace Fidry\FileSystem;
 
 use Symfony\Component\Filesystem\Exception\IOException;
 
-interface FileSystem extends SymfonyFilesystem
+interface FileSystem extends SymfonyFileSystem
 {
     /**
      * Returns whether a path is relative.

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -47,8 +47,6 @@ declare(strict_types=1);
 namespace Fidry\FileSystem;
 
 use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
-use Symfony\Component\Filesystem\Path;
 
 interface FileSystem extends SymfonyFilesystem
 {

--- a/src/NativeFileSystem.php
+++ b/src/NativeFileSystem.php
@@ -47,8 +47,7 @@ declare(strict_types=1);
 namespace Fidry\FileSystem;
 
 use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
-use Symfony\Component\Filesystem\Path;
+use Symfony\Component\Filesystem\Filesystem as NativeSymfonyFilesystem;
 use Webmozart\Assert\Assert;
 use function error_get_last;
 use function file_get_contents;
@@ -59,16 +58,8 @@ use function str_replace;
 use function sys_get_temp_dir;
 use const DIRECTORY_SEPARATOR;
 
-class NativeFileSystem extends SymfonyFilesystem
+class NativeFileSystem extends NativeSymfonyFilesystem implements FileSystem
 {
-    /**
-     * Returns whether a path is relative.
-     *
-     * @param string $path a path string
-     *
-     * @return bool returns true if the path is relative or empty, false if
-     *              it is absolute
-     */
     public function isRelativePath(string $path): bool
     {
         return !$this->isAbsolutePath($path);
@@ -84,15 +75,6 @@ class NativeFileSystem extends SymfonyFilesystem
         parent::dumpFile($filename, $content);
     }
 
-    /**
-     * Gets the contents of a file.
-     *
-     * @param string $file File path
-     *
-     * @throws IOException If the file cannot be read
-     *
-     * @return string File contents
-     */
     public function getFileContents(string $file): string
     {
         Assert::file($file);
@@ -114,14 +96,6 @@ class NativeFileSystem extends SymfonyFilesystem
         return $contents;
     }
 
-    /**
-     * Creates a temporary directory.
-     *
-     * @param string $namespace the directory path in the system's temporary directory
-     * @param string $className the name of the test class
-     *
-     * @return string the path to the created directory
-     */
     public function makeTmpDir(string $namespace, string $className): string
     {
         $shortClass = false !== ($pos = mb_strrpos($className, '\\'))
@@ -154,11 +128,6 @@ class NativeFileSystem extends SymfonyFilesystem
         return $tmpDir;
     }
 
-    /**
-     * Gets a namespaced temporary directory.
-     *
-     * @param string $namespace the directory path in the system's temporary directory
-     */
     public function getNamespacedTmpDir(string $namespace): string
     {
         // Usage of realpath() is important if the temporary directory is a

--- a/src/SymfonyFileSystem.php
+++ b/src/SymfonyFileSystem.php
@@ -57,15 +57,19 @@ interface SymfonyFileSystem
      *
      * @throws FileNotFoundException When originFile doesn't exist
      * @throws IOException           When copy fails
+     *
+     * @return void
      */
-    public function copy(string $originFile, string $targetFile, bool $overwriteNewerFiles = false): void;
+    public function copy(string $originFile, string $targetFile, bool $overwriteNewerFiles = false);
 
     /**
      * Creates a directory recursively.
      *
      * @throws IOException On any directory creation failure
+     *
+     * @return void
      */
-    public function mkdir(string|iterable $dirs, int $mode = 0o777): void;
+    public function mkdir(string|iterable $dirs, int $mode = 0o777);
 
     /**
      * Checks the existence of files or directories.
@@ -80,15 +84,19 @@ interface SymfonyFileSystem
      * @param int|null                $atime The access time as a Unix timestamp, if not supplied the current system time is used
      *
      * @throws IOException When touch fails
+     *
+     * @return void
      */
-    public function touch(string|iterable $files, ?int $time = null, ?int $atime = null): void;
+    public function touch(string|iterable $files, ?int $time = null, ?int $atime = null);
 
     /**
      * Removes files or directories.
      *
      * @throws IOException When removal fails
+     *
+     * @return void
      */
-    public function remove(string|iterable $files): void;
+    public function remove(string|iterable $files);
 
     /**
      * Change mode for an array of files or directories.
@@ -98,8 +106,10 @@ interface SymfonyFileSystem
      * @param bool $recursive Whether change the mod recursively or not
      *
      * @throws IOException When the change fails
+     *
+     * @return void
      */
-    public function chmod(string|iterable $files, int $mode, int $umask = 0o000, bool $recursive = false): void;
+    public function chmod(string|iterable $files, int $mode, int $umask = 0o000, bool $recursive = false);
 
     /**
      * Change the owner of an array of files or directories.
@@ -112,8 +122,10 @@ interface SymfonyFileSystem
      * @param bool       $recursive Whether change the owner recursively or not
      *
      * @throws IOException When the change fails
+     *
+     * @return void
      */
-    public function chown(string|iterable $files, string|int $user, bool $recursive = false): void;
+    public function chown(string|iterable $files, string|int $user, bool $recursive = false);
 
     /**
      * Change the group of an array of files or directories.
@@ -127,23 +139,29 @@ interface SymfonyFileSystem
      * @param bool                    $recursive Whether change the group recursively or not
      *
      * @throws IOException When the change fails
+     *
+     * @return void
      */
-    public function chgrp(string|iterable $files, string|int $group, bool $recursive = false): void;
+    public function chgrp(string|iterable $files, string|int $group, bool $recursive = false);
 
     /**
      * Renames a file or a directory.
      *
      * @throws IOException When target file or directory already exists
      * @throws IOException When origin cannot be renamed
+     *
+     * @return void
      */
-    public function rename(string $origin, string $target, bool $overwrite = false): void;
+    public function rename(string $origin, string $target, bool $overwrite = false);
 
     /**
      * Creates a symbolic link or copy a directory.
      *
      * @throws IOException When symlink fails
+     *
+     * @return void
      */
-    public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false): void;
+    public function symlink(string $originDir, string $targetDir, bool $copyOnWindows = false);
 
     /**
      * Creates a hard link, or several hard links to a file.
@@ -152,8 +170,10 @@ interface SymfonyFileSystem
      *
      * @throws FileNotFoundException When original file is missing or not a file
      * @throws IOException           When link fails, including if link already exists
+     *
+     * @return void
      */
-    public function hardlink(string $originFile, string|iterable $targetFiles): void;
+    public function hardlink(string $originFile, string|iterable $targetFiles);
 
     /**
      * Resolves links in paths.
@@ -189,8 +209,10 @@ interface SymfonyFileSystem
      *                                   - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
      *
      * @throws IOException When a file type is unknown
+     *
+     * @return void
      */
-    public function mirror(string $originDir, string $targetDir, ?Traversable $iterator = null, array $options = []): void;
+    public function mirror(string $originDir, string $targetDir, ?Traversable $iterator = null, array $options = []);
 
     /**
      * Returns whether the file path is an absolute path.
@@ -224,13 +246,8 @@ interface SymfonyFileSystem
      * @param bool            $lock    Whether the file should be locked when writing to it
      *
      * @throws IOException If the file is not writable
-     */
-    public function appendToFile(string $filename, $content, bool $lock = false): void;
-
-    /**
-     * Returns the content of a file as a string.
      *
-     * @throws IOException If the file cannot be read
+     * @return void
      */
-    public function readFile(string $filename): string;
+    public function appendToFile(string $filename, $content, /*bool $lock = false*/);
 }


### PR DESCRIPTION
This PR introduces a `FileSystem`. The goal is to be able to introduce another implementation which is needed in infection to ensure a readonly system.

The previous `FileSystem` was renamed `NativeFileSystem`. To make it easier to distinguish what comes from Symfony and what comes from this package, I extracted another interface declaring what comes purely from Symfony.