### PR TITLE
test: Remove deleted `--only-covered` infection option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COVERAGE_HTML = $(COVERAGE_DIR)/html
 TARGET_MSI = 100
 
 INFECTION_BIN = vendor/bin/infection
-INFECTION = php -d zend.enable_gc=0 $(INFECTION_BIN) --skip-initial-tests --coverage=$(COVERAGE_DIR) --only-covered --show-mutations --min-msi=100 --min-covered-msi=100 --ansi
+INFECTION = php -d zend.enable_gc=0 $(INFECTION_BIN) --skip-initial-tests --coverage=$(COVERAGE_DIR) --show-mutations --min-msi=100 --min-covered-msi=100 --ansi
 
 PHPUNIT_BIN = vendor/bin/phpunit
 PHPUNIT = php -d zend.enable_gc=0 $(PHPUNIT_BIN)


### PR DESCRIPTION
It only mutates covered files by default now.