### PR TITLE
fix: Deprecate the `isAbsolutePath()` and `isAbsolutePath()` in favour of the `Path` variants

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,4 +3,5 @@
 - The class `FileSystem` was renamed `NativeFileSystem`. `FileSystem` is now an
   interface.
 - Deprecated the `::getFileContents()` method in favour of `::readFile()`.
-- Deprecated the `::isRelativePath()` method in favour of `Path::isRelativePath()`.
+- Deprecated the `::isAbsolutePath()` method in favour of `Path::isAbsolute()`.
+- Deprecated the `::isRelativePath()` method in favour of `Path::isRelative()`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,4 +2,5 @@
 
 - The class `FileSystem` was renamed `NativeFileSystem`. `FileSystem` is now an
   interface.
-- Deprecated the `::getFileContents()` method in favour of the `::readFile()`.
+- Deprecated the `::getFileContents()` method in favour of `::readFile()`.
+- Deprecated the `::isRelativePath()` method in favour of `Path::isRelativePath()`.

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -53,7 +53,7 @@ interface FileSystem extends SymfonyFileSystem
 {
     /**
      * @deprecated Deprecated since 2.0. Use `Path::isRelative()` instead. Will be removed in 3.0.
-     * @see Path::isRelative
+     * @see Path::isRelative())
      */
     public function isRelativePath(string $path): bool;
 
@@ -61,7 +61,7 @@ interface FileSystem extends SymfonyFileSystem
 
     /**
      * @deprecated Use the `::readFile()` method. Deprecated since 2.0 and it will be removed in 3.0.
-     * @see readFile
+     * @see SymfonyFileSystem::readFile()
      *
      * @throws IOException If the file cannot be read
      */

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -52,18 +52,12 @@ use Symfony\Component\Finder\Finder;
 interface FileSystem extends SymfonyFileSystem
 {
     /**
-     * Returns whether a path is relative.
-     *
-     * @param string $path a path string
-     *
-     * @return bool returns true if the path is relative or empty, false if
-     *              it is absolute
+     * @deprecated Deprecated since 2.0. Use `Path::isRelativePath()` instead. Will be removed in 3.0.
+     * @see Path::isRelativePath
      */
     public function isRelativePath(string $path): bool;
 
     public function escapePath(string $path): string;
-
-    public function dumpFile(string $filename, $content = ''): void;
 
     /**
      * @deprecated Use the `::readFile()` method. Deprecated since 2.0 and it will be removed in 3.0.

--- a/src/FileSystem.php
+++ b/src/FileSystem.php
@@ -52,8 +52,8 @@ use Symfony\Component\Finder\Finder;
 interface FileSystem extends SymfonyFileSystem
 {
     /**
-     * @deprecated Deprecated since 2.0. Use `Path::isRelativePath()` instead. Will be removed in 3.0.
-     * @see Path::isRelativePath
+     * @deprecated Deprecated since 2.0. Use `Path::isRelative()` instead. Will be removed in 3.0.
+     * @see Path::isRelative
      */
     public function isRelativePath(string $path): bool;
 

--- a/src/SymfonyFileSystem.php
+++ b/src/SymfonyFileSystem.php
@@ -226,6 +226,7 @@ interface SymfonyFileSystem
      * Returns whether the file path is an absolute path.
      *
      * @deprecated Deprecated since 2.0. Use `Path::isAbsolute()` instead.
+     * @see Path::isAbsolute()
      */
     public function isAbsolutePath(string $file): bool;
 

--- a/src/SymfonyFileSystem.php
+++ b/src/SymfonyFileSystem.php
@@ -224,6 +224,8 @@ interface SymfonyFileSystem
 
     /**
      * Returns whether the file path is an absolute path.
+     *
+     * @deprecated Deprecated since 2.0. Use `Path::isAbsolute()` instead.
      */
     public function isAbsolutePath(string $file): bool;
 


### PR DESCRIPTION
- Deprecated the `::isAbsolutePath()` method in favour of `Path::isAbsolute()`.
- Deprecated the `::isRelativePath()` method in favour of `Path::isRelative()`.