### PR TITLE
feat!: Improve the FileSystemTestCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ An example of a PHPUnit test:
 
 <?php declare(strict_types=1);
 
-namespace App;
+namespace App\Tests;
 
 use Fidry\FileSystem\FS;
 use Fidry\FileSystem\Test\FileSystemTestCase;
@@ -134,25 +134,12 @@ use function is_string;
 
 final class MyAppFileSystemTest extends FileSystemTestCase
 {
-    // This method needs to be implemented by your test or base filesystem test class.
-    public static function getTmpDirNamespace(): string
-    {
-        // This is to make it thread safe with Infection. If you are not using
-        // infection or do not need thread safety, this can return a constant
-        // string, e.g. your project/library name.
-        $threadId = getenv('TEST_TOKEN');
-
-        if (!is_string($threadId)) {
-            $threadId = '';
-        }
-
-        return 'MyApp'.$threadId;
-    }
-
     public function test_it_works(): void
     {
+        // The temporary directory can be changed by overriding `::getTmpDirPrefix()`.
+    
         // This file is dumped into a temporary directory. Here,
-        // something like '/private/var/folders/p3/lkw0cgjj2fq0656q_9rd0mk80000gn/T/MyApp/MyAppFileSystemTest10000'
+        // something like '/private/var/folders/p3/lkw0cgjj2fq0656q_9rd0mk80000gn/T/AppTestsMyAppFileSystemTest10000'
         // on OSX.
         FS::dumpFile('file1', '');
         
@@ -162,6 +149,17 @@ final class MyAppFileSystemTest extends FileSystemTestCase
 
         self::assertSame(['file1'], $this->normalizePaths($files));
     }
+    
+    // Utility methods available:
+    /**
+     * @param iterable<string|Stringable> $paths
+     *
+     * @return list<string> File real paths relative to the current temporary directory
+     */
+    function normalizePaths(iterable $paths): array;
+    
+    static function safeChdir(string $directory): void;
+    static function safeGetCurrentWorkingDirectory(): string;
 }
 
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,13 @@
 
 - The class `FileSystem` was renamed `NativeFileSystem`. `FileSystem` is now an
   interface.
+- Made explicit the dependency on `ext-mbstring`. If you do not have this dependency
+  met use [symfony/polyfill-mbstring](https://packagist.org/packages/symfony/polyfill-mbstring).
 - Deprecated the `::getFileContents()` method in favour of `::readFile()`.
 - Deprecated the `::isAbsolutePath()` method in favour of `Path::isAbsolute()`.
 - Deprecated the `::isRelativePath()` method in favour of `Path::isRelative()`.
+- Deprecated the `::makeTmpDir()` method in favour of `::tmpDir()`.
+- Deprecated the `::getNamespacedTmpDir()` method in favour of `::tmpDir()`.
+- Deprecated the `FileSystemTestCase::getTmpDirNamespace()` has been removed. This was requiring too 
+  much boilerplate. Instead, the temporary directory is now already thread safe although it no longer
+  creates one unique directory.

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -40,5 +40,11 @@
         "FunctionCallRemoval": false,
         "MethodCallRemoval": false,
         "PublicVisibility": false,
+        "ProtectedVisibility": false,
+        "UnwrapStrReplace": {
+            "ignore": [
+                "Fidry\\FileSystem\\Test\\FileSystemTestCase::getTmpDirPrefix"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Simplify the usage by no longer requiring to implement an abstract method.

A significant (internal, but observable) change is that we no longer use a namespaced directory. Indeed, instead of having:

```
/path/to/system/default-tmp/
  TestCaseThreadSafeNamespace/
    tmpDir1
    tmpDir2
    ...
```

We now have:

```
/path/to/system/default-tmp/
  tmpDir1
  tmpDir2
  ...
```

Indeed, the creation of the temporary directory is already thread safe, so there is no need for the user to implement an abstract method. And because of it, we can remove the usage of a namespace which is not that useful and if anything may mess up the thread safety.